### PR TITLE
main: added replication controller namespace support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Optional:
 - `KRUD_DEPLOYMENT_KEY`: key to use to differentiate between two different controllers; defaults to `deployment`
 - `KRUD_K8S_ENDPOINT`: kubernetes endpoint; defaults to `http://localhost:8080`
 - `KRUD_LISTEN`: listen address; defaults to `:9500`
+- `KRUD_NAMESPACE`: the namespace the replication controller belongs to; defaults to `default`
 
 These options can also be specified on the command line. See `krud -help` for usage.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Optional:
 - `KRUD_DEPLOYMENT_KEY`: key to use to differentiate between two different controllers; defaults to `deployment`
 - `KRUD_K8S_ENDPOINT`: kubernetes endpoint; defaults to `http://localhost:8080`
 - `KRUD_LISTEN`: listen address; defaults to `:9500`
-- `KRUD_NAMESPACE`: the namespace the replication controller belongs to; defaults to `default`
+- `KRUD_NAMESPACE`: namespace of the replication controller; defaults to the kubernetes default
 
 These options can also be specified on the command line. See `krud -help` for usage.
 

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ func main() {
 	listen := fs.String("listen", ":9500", "")
 	deploymentKey := fs.String("deployment-key", "deployment", "Key to use to differentiate between two different controllers.")
 	controllerName := fs.String("controller-name", "", "Name of the replication controller to update.")
-	namespace := fs.String("namespace", "", "Namespace the replicationController belongs to.")
+	namespace := fs.String("namespace", api.NamespaceDefault, "Namespace the replication controller.")
 	k8sEndpoint := fs.String("k8s-endpoint", "http://localhost:8080", "URL of the Kubernetes API server")
 
 	if err := fs.Parse(os.Args[1:]); err != nil {
@@ -232,9 +232,6 @@ func (k *Krud) update(h *Webhook) error {
 	client, err := client.New(conf)
 	if err != nil {
 		return err
-	}
-	if k.Namespace == "" {
-		k.Namespace = api.NamespaceDefault
 	}
 	rcs := client.ReplicationControllers(k.Namespace)
 	oldRc, err := rcs.Get(k.ControllerName)

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ func main() {
 	listen := fs.String("listen", ":9500", "")
 	deploymentKey := fs.String("deployment-key", "deployment", "Key to use to differentiate between two different controllers.")
 	controllerName := fs.String("controller-name", "", "Name of the replication controller to update.")
+	namespace := fs.String("namespace", "", "Namespace the replicationController belongs to.")
 	k8sEndpoint := fs.String("k8s-endpoint", "http://localhost:8080", "URL of the Kubernetes API server")
 
 	if err := fs.Parse(os.Args[1:]); err != nil {
@@ -44,6 +45,7 @@ func main() {
 		DeploymentKey:  *deploymentKey,
 		ControllerName: *controllerName,
 		Endpoint:       *k8sEndpoint,
+		Namespace:      *namespace,
 	}
 
 	http.HandleFunc("/push", k.push)
@@ -54,6 +56,7 @@ func main() {
 type Krud struct {
 	DeploymentKey  string
 	ControllerName string
+	Namespace      string
 	Endpoint       string
 
 	// Hooks contains all incoming webhooks
@@ -230,8 +233,10 @@ func (k *Krud) update(h *Webhook) error {
 	if err != nil {
 		return err
 	}
-	ns := api.NamespaceDefault
-	rcs := client.ReplicationControllers(ns)
+	if k.Namespace == "" {
+		k.Namespace = api.NamespaceDefault
+	}
+	rcs := client.ReplicationControllers(k.Namespace)
 	oldRc, err := rcs.Get(k.ControllerName)
 	if err != nil {
 		return err
@@ -269,7 +274,7 @@ func (k *Krud) update(h *Webhook) error {
 	}
 	ruc := kubectl.NewRollingUpdaterClient(client)
 	println("doing rolling update")
-	err = kubectl.NewRollingUpdater(ns, ruc).Update(&ruconf)
+	err = kubectl.NewRollingUpdater(k.Namespace, ruc).Update(&ruconf)
 	println("done")
 	k.Lock()
 	h.UpdateSuccess = err == nil


### PR DESCRIPTION
Currently krud only works on the default namespace. Some replication
controllers may exist on other namespaces. This fix adds support for
defining a namespace for a replication controller.
